### PR TITLE
Update hacs.json to unblock HACS issue

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "Remote Home-Assistant",
   "render_readme": true,
-  "iot_class": "Local Polling"
+  "iot_class": "Local Polling",
+  "version": "1.0.0"
 }


### PR DESCRIPTION
Trying to help get this issue resolved, the current failure is caused by the missing version key: https://github.com/hacs/default/pull/757

I'm unsure what the old version was, hopefully 1.0.0 is okay.