### PR TITLE
Fix broken options flow

### DIFF
--- a/custom_components/remote_homeassistant/config_flow.py
+++ b/custom_components/remote_homeassistant/config_flow.py
@@ -188,9 +188,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self.filters = None
         self.events = None
         self.options = None
-        self.remote = self.hass.data[DOMAIN][self.config_entry.entry_id][
-            CONF_REMOTE_CONNECTION
-        ]
 
     async def async_step_init(self, user_input=None):
         """Manage basic options."""
@@ -200,6 +197,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         domains, _ = self._domains_and_entities()
         domains = set(domains + self.config_entry.options.get(CONF_LOAD_COMPONENTS, []))
+
+        remote = self.hass.data[DOMAIN][self.config_entry.entry_id][
+            CONF_REMOTE_CONNECTION
+        ]
 
         return self.async_show_form(
             step_id="init",
@@ -223,7 +224,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_SERVICES,
                         default=self._default(CONF_SERVICES),
-                    ): cv.multi_select(self.remote.proxy_services.services),
+                    ): cv.multi_select(remote.proxy_services.services),
                 }
             ),
         )

--- a/custom_components/remote_homeassistant/proxy_services.py
+++ b/custom_components/remote_homeassistant/proxy_services.py
@@ -23,11 +23,11 @@ class ProxyServices:
     @property
     def services(self):
         """Return list of service names."""
-        services = []
+        result = []
         for domain, services in self.remote_services.items():
             for service in services.keys():
-                services.append(f"{domain}.{service}")
-        return sorted(services)
+                result.append(f"{domain}.{service}")
+        return sorted(result)
 
     async def load(self):
         """Call to make initial registration of services."""
@@ -55,7 +55,7 @@ class ProxyServices:
             return
 
         description_cache = self.hass.data[SERVICE_DESCRIPTION_CACHE]
-        for service in self.entry.options[CONF_SERVICES]:
+        for service in self.entry.options.get(CONF_SERVICES, []):
             domain, service_name = service.split(".")
             service = service_prefix + service_name
 


### PR DESCRIPTION
Trying to access self.hass in the constructor of an options flow does
not work as it has not been set yet. This change moves that code to
where it's actually used.

Fixes #100.