### PR TITLE
Notice that shows remote node has no configuration options instead of throwing a 500 error

### DIFF
--- a/custom_components/remote_homeassistant/config_flow.py
+++ b/custom_components/remote_homeassistant/config_flow.py
@@ -208,7 +208,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         """Manage basic options."""
         if self.config_entry.unique_id == REMOTE_ID:
-            return
+            return self.async_abort(reason="not_supported")
         
         if user_input is not None:
             self.options = user_input.copy()

--- a/custom_components/remote_homeassistant/translations/en.json
+++ b/custom_components/remote_homeassistant/translations/en.json
@@ -80,7 +80,7 @@
       }
     },
     "abort": {
-      "not_supported": "No configuration options supported"
+      "not_supported": "No configuration options supported for a remote node"
     }
   }
 }

--- a/custom_components/remote_homeassistant/translations/en.json
+++ b/custom_components/remote_homeassistant/translations/en.json
@@ -78,6 +78,9 @@
             "add_new_event": "Add new event"
         }
       }
+    },
+    "abort": {
+      "not_supported": "No configuration options supported"
     }
   }
 }


### PR DESCRIPTION
Fixes #202 
Fixes #206 