### PR TITLE
Fix configuration with regards to hassfest

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -10,6 +10,6 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-        - uses: "actions/checkout@v2"
+        - uses: "actions/checkout@v3"
         - uses: "home-assistant/actions/hassfest@master"
 

--- a/custom_components/remote_homeassistant/manifest.json
+++ b/custom_components/remote_homeassistant/manifest.json
@@ -1,18 +1,18 @@
 {
   "domain": "remote_homeassistant",
   "name": "Remote Home-Assistant",
-  "issue_tracker": "https://github.com/custom-components/remote_homeassistant/issues",
-  "documentation": "https://github.com/custom-components/remote_homeassistant",
-  "dependencies": ["http"],
-  "config_flow": true,
   "codeowners": [
     "@lukas-hetzenecker",
     "@postlund"
   ],
+  "config_flow": true,
+  "dependencies": ["http"],
+  "documentation": "https://github.com/custom-components/remote_homeassistant",
+  "iot_class": "local_push"
+  "issue_tracker": "https://github.com/custom-components/remote_homeassistant/issues",
   "requirements": [],
+  "version": "3.11",
   "zeroconf": [
     "_home-assistant._tcp.local."
   ],
-  "version": "3.11",
-  "iot_class": "local_push"
 }

--- a/custom_components/remote_homeassistant/manifest.json
+++ b/custom_components/remote_homeassistant/manifest.json
@@ -8,11 +8,11 @@
   "config_flow": true,
   "dependencies": ["http"],
   "documentation": "https://github.com/custom-components/remote_homeassistant",
-  "iot_class": "local_push"
+  "iot_class": "local_push",
   "issue_tracker": "https://github.com/custom-components/remote_homeassistant/issues",
   "requirements": [],
   "version": "3.11",
   "zeroconf": [
     "_home-assistant._tcp.local."
-  ],
+  ]
 }

--- a/custom_components/remote_homeassistant/services.yaml
+++ b/custom_components/remote_homeassistant/services.yaml
@@ -1,3 +1,3 @@
 reload:
-  name: Reload remote_homeassistant
+  name: Reload Remote Home-Assistant
   description: Reload remote_homeassistant and re-process yaml configuration.

--- a/custom_components/remote_homeassistant/services.yaml
+++ b/custom_components/remote_homeassistant/services.yaml
@@ -1,2 +1,3 @@
 reload:
+  name: Reload remote_homeassistant
   description: Reload remote_homeassistant and re-process yaml configuration.

--- a/custom_components/remote_homeassistant/translations/de.json
+++ b/custom_components/remote_homeassistant/translations/de.json
@@ -30,16 +30,6 @@
       "already_configured": "Bereits konfiguriert"
     }
   },
-  "state": {
-    "_": {
-      "disconnected": "Getrennt",
-      "connecting": "Verbindet",
-      "connected": "Verbunden",
-      "reconnecting": "Wiederverbinden",
-      "auth_invalid": "Ungültiger Zugangstoken",
-      "auth_required": "Authentifizierung erforderlich"
-    }
-  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/remote_homeassistant/translations/en.json
+++ b/custom_components/remote_homeassistant/translations/en.json
@@ -30,16 +30,6 @@
       "already_configured": "Already configured"
     }
   },
-  "state": {
-    "_": {
-      "disconnected": "Disconnected",
-      "connecting": "Connecting",
-      "connected": "Connected",
-      "reconnecting": "Re-connecting",
-      "auth_invalid": "Invalid access token",
-      "auth_required": "Authentication Required"
-    }
-  },
   "options": {
     "step": {
       "init": {
@@ -86,8 +76,8 @@
   },
   "services": {
     "execute": {
-      "name": "Reload remote_homeassistent"
+      "name": "Reload Remote Home-Assistant",
       "description": "Reload remote_homeassistant and re-process yaml configuration"
+	}
   }
-
 }

--- a/custom_components/remote_homeassistant/translations/en.json
+++ b/custom_components/remote_homeassistant/translations/en.json
@@ -83,5 +83,11 @@
     "abort": {
       "not_supported": "No configuration options supported for a remote node"
     }
+  },
+  "services": {
+    "execute": {
+      "name": "Reload remote_homeassistent"
+      "description": "Reload remote_homeassistant and re-process yaml configuration"
   }
+
 }

--- a/custom_components/remote_homeassistant/translations/pt-BR.json
+++ b/custom_components/remote_homeassistant/translations/pt-BR.json
@@ -30,16 +30,6 @@
       "already_configured": "Já configurado"
     }
   },
-  "state": {
-    "_": {
-      "disconnected": "Desconectado",
-      "connecting": "Conectando",
-      "connected": "Conectado",
-      "reconnecting": "Reconectando",
-      "auth_invalid": "Token de acesso inválido",
-      "auth_required": "Autentificação requerida"
-    }
-  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/remote_homeassistant/translations/sensor.de.json
+++ b/custom_components/remote_homeassistant/translations/sensor.de.json
@@ -1,0 +1,12 @@
+{
+  "state": {
+    "remote_homeassistant___": {
+      "disconnected": "Getrennt",
+      "connecting": "Verbindet",
+      "connected": "Verbunden",
+      "reconnecting": "Wiederverbinden",
+      "auth_invalid": "Ungültiger Zugangstoken",
+      "auth_required": "Authentifizierung erforderlich"
+    }
+  }
+}

--- a/custom_components/remote_homeassistant/translations/sensor.en.json
+++ b/custom_components/remote_homeassistant/translations/sensor.en.json
@@ -1,0 +1,12 @@
+{
+  "state": {
+    "remote_homeassistant___": {
+      "disconnected": "Disconnected",
+      "connecting": "Connecting",
+      "connected": "Connected",
+      "reconnecting": "Re-connecting",
+      "auth_invalid": "Invalid access token",
+      "auth_required": "Authentication Required"
+    }
+  }
+}

--- a/custom_components/remote_homeassistant/translations/sensor.pt-BR.json
+++ b/custom_components/remote_homeassistant/translations/sensor.pt-BR.json
@@ -1,0 +1,12 @@
+{
+  "state": {
+    "remote_homeassistant___": {
+      "disconnected": "Desconectado",
+      "connecting": "Conectando",
+      "connected": "Conectado",
+      "reconnecting": "Reconectando",
+      "auth_invalid": "Token de acesso inválido",
+      "auth_required": "Autentificação requerida"
+    }
+  }
+}


### PR DESCRIPTION
This fixes the configuration files and services.yaml with regards to hassfest.

The sensor translations need to be moved to a separate file.
This may still need some adjustement as far as the key is concerned.
I followed https://community.home-assistant.io/t/how-to-send-translation-arguments-to-the-translation-custom-integration/143965/3) and hassfest's checks warnings/error messages.